### PR TITLE
More intuitive message on error status codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Related post: https://blog.yusanshi.com/2019-12-17-emgithub/
 - [ ] Line count
 - [ ] Beautify transition
 
+## Examples
+
+https://blog.yusanshi.com/2019-12-17-emgithub/#%E6%B5%8B%E8%AF%95
+
+
 ## Get started
 
 There are two ways to use the service.
@@ -20,14 +25,9 @@ There are two ways to use the service.
 Supposed you want to embed this README file whose URL is `https://github.com/yusanshi/embed_like_gist/blob/master/README.md`. The first way is to visit https://emgithub.com/ and paste the URL. The other is to simply add "em" before "github.com". For this README file, you edit URL into `https://emgithub.com/yusanshi/embed_like_gist/blob/master/README.md`, then press Enter.
 
 
-## Examples
-
-https://blog.yusanshi.com/2019-12-17-emgithub/#%E6%B5%8B%E8%AF%95
-
 ## Known issues
 
 - Different style in one page is not supported
-- Sometimes first embeded code is not highlighted
 
 PR is always welcomed.
 

--- a/embed.js
+++ b/embed.js
@@ -17,8 +17,8 @@ function embed() {
   document.write(`
   <style>.lds-ring{margin:0 auto;position:relative;width:60px;height:60px}.lds-ring div{box-sizing:border-box;display:block;position:absolute;width:48px;height:48px;margin:6px;border:6px solid #fff;border-radius:50%;animation:lds-ring 1.2s cubic-bezier(0.5,0,0.5,1) infinite;border-color:#888 transparent transparent transparent}.lds-ring div:nth-child(1){animation-delay:-.45s}.lds-ring div:nth-child(2){animation-delay:-.3s}.lds-ring div:nth-child(3){animation-delay:-.15s}@keyframes lds-ring{0%{transform:rotate(0deg)}100%{transform:rotate(360deg)}}</style>
   <div class="${pathSplit.join("-")}"><div class="lds-ring"><div></div><div></div><div></div><div></div></div></div>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/styles/${style}.min.css">
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/styles/${style}.min.css">
   `);
 
   fetch(rawFile).then(function (response) {
@@ -31,10 +31,26 @@ function embed() {
         var pre = document.createElement("pre");
         var code = document.createElement("code");
         code.textContent = text;
-        hljs.highlightBlock(code);
-        pre.appendChild(code);
-        allDiv[i].innerHTML = "";
-        allDiv[i].appendChild(pre);
+        try {
+          hljs.highlightBlock(code);
+          pre.appendChild(code);
+          allDiv[i].innerHTML = "";
+          allDiv[i].appendChild(pre);
+        } catch (error) {
+          console.log(error);
+          console.log("Trying to reload highlight.js");
+          var hljsScript = document.createElement("script");
+          hljsScript.targetDiv = allDiv[i];
+          hljsScript.onload = function () {
+            console.log("Succeeded reloading highlight.js");
+            hljs.highlightBlock(code);
+            pre.appendChild(code);
+            this.targetDiv.innerHTML = "";
+            this.targetDiv.appendChild(pre);
+          }
+          hljsScript.src = "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js";
+          allDiv[i].insertAdjacentElement("afterend", hljsScript);
+        }
       }
     }
   }).catch(function (error) {
@@ -45,7 +61,6 @@ function embed() {
         var pre = document.createElement("pre");
         var code = document.createElement("code");
         code.textContent = `Failed to write ${rawFile}: ${error.message}`;
-        hljs.highlightBlock(code);
         pre.appendChild(code);
         allDiv[i].innerHTML = "";
         allDiv[i].appendChild(pre);

--- a/embed.js
+++ b/embed.js
@@ -22,7 +22,10 @@ function embed() {
   `);
 
   fetch(rawFile).then(function (response) {
-    return response.text()
+    if (response.ok) {
+      return response.text();
+    }
+    throw new Error(`Response was not ok: ${response.status} ${response.statusText}`);
   }).then(function (text) {
     console.log(`Succeeded in fetching ${rawFile}`);
     var allDiv = document.getElementsByClassName(pathSplit.join("-"));


### PR DESCRIPTION
It turns out that an error status code of fetching does not result in an error, so `catch` clauses will not be executed and the error message from raw.githubusercontent.com is displayed. This patch enables checks for responses' status code to make those errors more intuitive.

    404: Not Found

=>

    Failed to write https://raw.githubusercontent.com/vuejs//dev/src/core/index.js: Response was not ok: 404 Not Found

<https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#Checking_that_the_fetch_was_successful>