### PR TITLE
Support embed a code snippet

### DIFF
--- a/404.html
+++ b/404.html
@@ -220,7 +220,7 @@
   <!-- In fact, the following is optional, here we make it to be loaded in advance -->
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js"></script>
   <script
-    src="https://cdn.jsdelivr.net/npm/highlightjs-line-numbers.js@2.7.0/dist/highlightjs-line-numbers.min.js"></script>
+    src="https://cdn.jsdelivr.net/npm/highlightjs-line-numbers.js@2.8.0/dist/highlightjs-line-numbers.min.js"></script>
   <script>
     $(function () {
       // Initialize popovers

--- a/404.html
+++ b/404.html
@@ -27,10 +27,14 @@
 <body>
   <main role="main" class="container py-5">
     <h1>Embed Like Gist</h1>
-    <p class="lead">Embed a file from Github repository just like <a target="_blank"
-        href="https://gist.github.com/">Github Gist</a>.<br>Paste URL of the file you would like to embed.
-      You can also simply add "em" before
-      "github.com" in address bar.</p>
+    <p class="lead">Embed a file from Github repository just like <a target="_blank" href="https://gist.github.com/">Github
+      Gist</a>.<br>Paste URL of the file you would like to embed.
+  You can also simply add "em" before
+  "github.com" in address bar. Permanent links to <a target="_blank"
+      href="https://docs.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files">a
+      file</a> or <a target="_blank"
+      href="https://docs.github.com/en/github/managing-your-work-on-github/creating-a-permanent-link-to-a-code-snippet">a
+      code snippet</a> are supported.</p>
     <form id="goForm" class="mb-4">
       <div class="input-group input-group-lg mb-3">
         <input type="text" name="target" id="target" class="form-control" required>
@@ -278,7 +282,7 @@
 
       if (["/", "/index.html", "/index.htm"].includes(window.location.pathname)) {
         // Is entering the site directly
-        $("#target").attr("placeholder", "https://github.com/user/repository/blob/branch/src/hello.cpp");
+        $("#target").attr("placeholder", "https://github.com/user/repository/blob/branch/src/hello.cpp#L2-L6");
       } else {
         // 404 triggered. Fill in target and simulate clicking
         $("#target").val("https://github.com" + window.location.pathname);

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ There are two ways to use the service.
 
 Supposed you want to embed the file `https://github.com/pytorch/pytorch/blob/master/torch/nn/cpp.py`. The first way is to visit https://emgithub.com/ and paste the URL. The other is to simply add "em" before "github.com". For this `cpp.py` file, you edit URL into `https://emgithub.com/pytorch/pytorch/blob/master/torch/nn/cpp.py`, then press Enter.
 
+Permanent links to [a file](https://docs.github.com/en/github/managing-files-in-a-repository/getting-permanent-links-to-files) or [a code snippet](https://docs.github.com/en/github/managing-your-work-on-github/creating-a-permanent-link-to-a-code-snippet) are supported.
+
 ![](https://img.yusanshi.com/upload/20200301135039426771.gif)
 
 ## TODO
@@ -23,8 +25,9 @@ Supposed you want to embed the file `https://github.com/pytorch/pytorch/blob/mas
 - [x] Add metadata
 - [x] Line count
 - [x] Remember options using localStorage
+- [x] Code slice
 - [ ] Different styles in one page
-- [ ] Code slice
+
 
 PR is always welcomed.
 

--- a/embed.js
+++ b/embed.js
@@ -11,8 +11,8 @@ function embed() {
   const showLineNumbers = params.get("showLineNumbers") === "on";
   const showFileMeta = params.get("showFileMeta") === "on";
   const lineSplit = target.hash.split("-");
-  const startLine = lineSplit !== "" && lineSplit[0].replace("#L", "") || -1;
-  const endLine = lineSplit !== "" && lineSplit.length > 1 && lineSplit[1].replace("L", "") || -1;
+  const startLine = target.hash !== "" && lineSplit[0].replace("#L", "") || -1;
+  const endLine = target.hash !== "" && lineSplit.length > 1 && lineSplit[1].replace("L", "") || -1;
   const pathSplit = target.pathname.split("/");
   const user = pathSplit[1];
   const repository = pathSplit[2];
@@ -103,7 +103,7 @@ ${error}`;
     const allDiv = document.getElementsByClassName(className);
     for (let i = 0; i < allDiv.length; i++) {
       if (allDiv[i].getElementsByClassName("lds-ring").length) {
-        embedCodeToTarget(allDiv[i], errorMsg, showBorder, showLineNumbers, showFileMeta, isDarkStyle, target.href, rawFileURL, 'plaintext', startLine, endLine);
+        embedCodeToTarget(allDiv[i], errorMsg, showBorder, showLineNumbers, showFileMeta, isDarkStyle, target.href, rawFileURL, 'plaintext', -1, -1);
       }
     }
   });
@@ -167,9 +167,9 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
 
   if (showFileMeta) {
     const meta = document.createElement("div");
-    const fileURLSplit = fileURL.split("/");
+    const rawFileURLSplit = rawFileURL.split("/");
     meta.innerHTML = `<a target="_blank" href="${rawFileURL}" style="float:right">view raw</a>
-<a target="_blank" href="${fileURL}">${fileURLSplit[fileURLSplit.length - 1]}</a>
+<a target="_blank" href="${fileURL}">${rawFileURLSplit[rawFileURLSplit.length - 1]}</a>
 delivered <span class="hide-in-phone">with ❤ </span>by <a target="_blank" href="https://emgithub.com">EmGithub</a>`;
     meta.classList.add("file-meta");
     if (!isDarkStyle) {


### PR DESCRIPTION
Support embed a code snippet by using the GitHub's permanent link. 

I tested it briefly, and it works well.

![image](https://user-images.githubusercontent.com/20675747/87925529-fd3f6080-cab2-11ea-81be-660e42e7b17f.png)

Some things about GitHub permanent links can be found here: https://docs.github.com/en/github/managing-your-work-on-github/creating-a-permanent-link-to-a-code-snippet