### PR TITLE
Add copy button

### DIFF
--- a/404.html
+++ b/404.html
@@ -225,7 +225,7 @@
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/postscribe@2.0.8/dist/postscribe.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.8/clipboard.min.js"></script>
   <!-- In fact, the following is optional, here we make it to be loaded in advance -->
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js"></script>
   <script

--- a/404.html
+++ b/404.html
@@ -146,7 +146,7 @@
       </div>
       <div class="custom-control custom-checkbox custom-control-inline">
         <input type="checkbox" class="custom-control-input" name="showCopy" id="showCopy" checked>
-        <label class="custom-control-label" for="showCopy">Show Copy Button</label>
+        <label class="custom-control-label" for="showCopy">Copy button</label>
       </div>
     </form>
     <label for="embededCode">Code to embed</label>

--- a/404.html
+++ b/404.html
@@ -235,7 +235,7 @@
       $('[data-toggle="popover"]').popover();
 
       // Load options from localStorage if possible
-      ['showBorder', 'showLineNumbers', 'showFileMeta'].forEach(e => {
+      ['showBorder', 'showLineNumbers', 'showFileMeta', 'showCopy'].forEach(e => {
         const isShown = localStorage.getItem(e);
         if (isShown !== null) {
           document.getElementById(e).checked = (isShown === 'true');

--- a/404.html
+++ b/404.html
@@ -251,7 +251,7 @@
         e.preventDefault();
 
         // Save current options using localStorage
-        ['showBorder', 'showLineNumbers', 'showFileMeta'].forEach(e => {
+        ['showBorder', 'showLineNumbers', 'showFileMeta', 'showCopy'].forEach(e => {
           const newValue = document.getElementById(e).checked ? 'true' : 'false';
           localStorage.setItem(e, newValue);
         });

--- a/404.html
+++ b/404.html
@@ -148,10 +148,6 @@
         <input type="checkbox" class="custom-control-input" name="showCopy" id="showCopy" checked>
         <label class="custom-control-label" for="showCopy">Show Copy Button</label>
       </div>
-      <div class="custom-control custom-checkbox custom-control-inline">
-        <input type="checkbox" class="custom-control-input" name="showShare" id="showShare" checked>
-        <label class="custom-control-label" for="showShare">Show Share Button</label>
-      </div>
     </form>
     <label for="embededCode">Code to embed</label>
     <div class="input-group input-group-lg mb-3">
@@ -229,6 +225,7 @@
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/postscribe@2.0.8/dist/postscribe.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js"></script>
   <!-- In fact, the following is optional, here we make it to be loaded in advance -->
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js"></script>
   <script

--- a/404.html
+++ b/404.html
@@ -144,6 +144,14 @@
         <input type="checkbox" class="custom-control-input" name="showFileMeta" id="showFileMeta" checked>
         <label class="custom-control-label" for="showFileMeta">File metadata</label>
       </div>
+      <div class="custom-control custom-checkbox custom-control-inline">
+        <input type="checkbox" class="custom-control-input" name="showCopy" id="showCopy" checked>
+        <label class="custom-control-label" for="showCopy">Show Copy Button</label>
+      </div>
+      <div class="custom-control custom-checkbox custom-control-inline">
+        <input type="checkbox" class="custom-control-input" name="showShare" id="showShare" checked>
+        <label class="custom-control-label" for="showShare">Show Share Button</label>
+      </div>
     </form>
     <label for="embededCode">Code to embed</label>
     <div class="input-group input-group-lg mb-3">

--- a/404.html
+++ b/404.html
@@ -225,7 +225,6 @@
   <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/js/bootstrap.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/postscribe@2.0.8/dist/postscribe.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.8/clipboard.min.js"></script>
   <!-- In fact, the following is optional, here we make it to be loaded in advance -->
   <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/highlight.min.js"></script>
   <script

--- a/embed.js
+++ b/embed.js
@@ -74,7 +74,6 @@ function embed() {
   position: relative;
 }
 
-/* TODO: be sure to handle dark/light themes */
 .emgithub-toolbar {
   position: absolute;
   height: 40px;

--- a/embed.js
+++ b/embed.js
@@ -208,7 +208,7 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
   if(showCopy) {
     const toolbar = document.createElement('div');
     toolbar.classList.add('toolbar');
-    
+
     const copyButton = document.createElement('a');
     copyButton.classList.add('copy-btn');
     if(isDarkStyle) {
@@ -223,7 +223,7 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
       e.cancelBubble = true;
       copyTextToClipboard(codeText);
     });
-    
+
     toolbar.appendChild(copyButton);
     targetDiv.appendChild(toolbar);
   }

--- a/embed.js
+++ b/embed.js
@@ -220,7 +220,6 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
   // Not use a real `pre` to avoid style being overwritten
   // Simulate a real one by using its default style
   const customPre = document.createElement("div");
-  customPre.classList.add('emgithub-code');
   customPre.style.whiteSpace = "pre";
   customPre.style.tabSize = tabSize;
   customPre.appendChild(code);

--- a/embed.js
+++ b/embed.js
@@ -208,7 +208,7 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
     
     let clipboard = new ClipboardJS(copyButton);
     clipboard.on('success', function(e) {    
-        e.clearSelection();
+      e.clearSelection();
     });
 
     fileContainer.appendChild(toolbar);

--- a/embed.js
+++ b/embed.js
@@ -185,10 +185,9 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
   code.classList.add(lang);
   if (startLine > 0) {
     codeTextSplit = codeText.split("\n");
-    code.textContent = codeTextSplit.slice(startLine - 1, endLine).join("\n");
-  } else {
-    code.textContent = codeText;
+    codeText = codeTextSplit.slice(startLine - 1, endLine).join("\n");
   }
+  code.textContent = codeText;
   if (typeof hljs != "undefined" && typeof hljs.highlightBlock != "undefined") {
     hljs.highlightBlock(code);
   }

--- a/embed.js
+++ b/embed.js
@@ -200,17 +200,10 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
     if(isDarkStyle) {
       copyButton.classList.add('dark-copy-btn');
     }
-    copyButton.setAttribute('data-clipboard-target', `#${targetDivID} .emgithub-code`)
     copyButton.href = 'javascript:void(0);'
     copyButton.innerHTML = 'Copy';
     
     toolbar.appendChild(copyButton);
-    
-    let clipboard = new ClipboardJS(copyButton);
-    clipboard.on('success', function(e) {    
-      e.clearSelection();
-    });
-
     fileContainer.appendChild(toolbar);
   }
 

--- a/embed.js
+++ b/embed.js
@@ -70,6 +70,47 @@ function embed() {
     display: none;
   }
 }
+.emgithub-container {
+  position: relative;
+}
+
+/* TODO: be sure to handle dark/light themes */
+.emgithub-toolbar {
+  position: absolute;
+  height: 40px;
+  width: 64px;
+  right: 0px;
+  padding: 5px;
+}
+
+.emgithub-copy-btn {
+  display: none;
+  border: 1px solid black;
+  border-radius: 3px;
+  padding: 6px;
+  color: #586069;
+  background-color: #f7f7f7;
+}
+
+.emgithub-container:hover .emgithub-copy-btn {
+  display: block;
+}
+
+.emgithub-container:hover .emgithub-copy-btn.dark-copy-btn {
+  color: #f7f7f7;
+  background-color: #586069;
+}
+
+.emgithub-container .emgithub-copy-btn:hover {
+  color: #f7f7f7;
+  background-color: #586069;
+}
+
+.emgithub-container .emgithub-copy-btn.dark-copy-btn:hover {
+  color: #586069;
+  background-color: #f7f7f7;
+}
+
 </style>
 `);
 
@@ -155,10 +196,17 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
   const toolbar = document.createElement('div');
   toolbar.classList.add('emgithub-toolbar');
   if(showCopy) {
-    const copyButton = document.createElement('button');
+    const copyButton = document.createElement('a');
+    copyButton.classList.add('emgithub-copy-btn');
+    if(isDarkStyle) {
+      copyButton.classList.add('dark-copy-btn');
+    }
     copyButton.setAttribute('data-clipboard-target', `#${targetDivID} .emgithub-code`)
+    copyButton.href = 'javascript:void(0);'
     copyButton.innerHTML = 'Copy';
-    fileContainer.appendChild(copyButton);
+    
+    toolbar.appendChild(copyButton);
+    
     let clipboard = new ClipboardJS(copyButton);
     clipboard.on('success', function(e) {    
         e.clearSelection();

--- a/embed.js
+++ b/embed.js
@@ -241,3 +241,28 @@ delivered <span class="hide-in-phone">with ❤ </span>by <a target="_blank" href
   targetDiv.innerHTML = "";
   targetDiv.appendChild(fileContainer);
 }
+
+// https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
+function copyTextToClipboard(text) {
+  if (!navigator.clipboard) {
+    fallbackCopyTextToClipboard(text);
+    return;
+  }
+  navigator.clipboard.writeText(text)
+}
+
+function fallbackCopyTextToClipboard(text) {
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.style.position = "fixed"; //avoid scrolling to bottom
+  document.body.appendChild(textArea);
+  textArea.focus();
+  textArea.select();
+
+  try {
+    document.execCommand('copy');
+  } catch (err) {
+    console.error('fallbackCopyTextToClipboard: Oops, unable to copy', err);
+  }
+  document.body.removeChild(textArea);
+}

--- a/embed.js
+++ b/embed.js
@@ -9,6 +9,8 @@ function embed() {
   const showBorder = params.get("showBorder") === "on";
   const showLineNumbers = params.get("showLineNumbers") === "on";
   const showFileMeta = params.get("showFileMeta") === "on";
+  const showCopy = params.get("showCopy") === "on";
+  const showShare = params.get("showShare") === "on";
   const lineSplit = target.hash.split("-");
   const startLine = target.hash !== "" && lineSplit[0].replace("#L", "") || -1;
   const endLine = target.hash !== "" && lineSplit.length > 1 && lineSplit[1].replace("L", "") || startLine;
@@ -95,12 +97,12 @@ function embed() {
 
   Promise.all(showLineNumbers ? [fetchFile, loadHLJS, loadHLJSNum] : [fetchFile, loadHLJS]).then((result) => {
     const targetDiv = document.getElementById(containerId);
-    embedCodeToTarget(targetDiv, result[0], showBorder, showLineNumbers, showFileMeta, isDarkStyle, target.href, rawFileURL, fileExtension, startLine, endLine, tabSize);
+    embedCodeToTarget(targetDiv, result[0], showBorder, showLineNumbers, showFileMeta, showCopy, showShare, isDarkStyle, target.href, rawFileURL, fileExtension, startLine, endLine, tabSize);
   }).catch((error) => {
     const errorMsg = `Failed to process ${rawFileURL}
 ${error}`;
     const targetDiv = document.getElementById(containerId);
-    embedCodeToTarget(targetDiv, errorMsg, showBorder, showLineNumbers, showFileMeta, isDarkStyle, target.href, rawFileURL, 'plaintext', -1, -1, tabSize);
+    embedCodeToTarget(targetDiv, errorMsg, showBorder, showLineNumbers, showFileMeta, showCopy, showShare, isDarkStyle, target.href, rawFileURL, 'plaintext', -1, -1, tabSize);
   });
 }
 
@@ -114,7 +116,7 @@ function loadScript(src) {
   });
 }
 
-function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, showFileMeta, isDarkStyle, fileURL, rawFileURL, lang, startLine, endLine, tabSize) {
+function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, showFileMeta, showCopy, showShare, isDarkStyle, fileURL, rawFileURL, lang, startLine, endLine, tabSize) {
   const fileContainer = document.createElement("div");
   fileContainer.style.margin = "1em 0";
 
@@ -148,6 +150,23 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
       singleLine: true,
       startFrom: startLine > 0 ? Number.parseInt(startLine) : 1
     });
+  }
+
+  const toolbar = document.createElement('div');
+  toolbar.classList.add('emgithub-toolbar');
+  if(showCopy) {
+    const copyButton = document.createElement('button');
+    copyButton.innerHTML = 'Copy';
+    fileContainer.appendChild(copyButton);
+  }
+  if(showShare) {
+    const shareButton = document.createElement('button');
+    shareButton.innerHTML = 'Share';
+    fileContainer.appendChild(shareButton);
+  }
+
+  if(showCopy || showShare) {
+    fileContainer.appendChild(toolbar);
   }
 
   // Not use a real `pre` to avoid style being overwritten

--- a/embed.js
+++ b/embed.js
@@ -33,90 +33,96 @@ function embed() {
 <style>.hljs-ln-numbers{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;text-align:right;color:#ccc;vertical-align:top}.hljs-ln td.hljs-ln-numbers{padding-right:1.25rem}</style>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.17.1/build/styles/${style}.min.css">
 <style>
-.file-meta {
+.emgithub-container .file-meta {
   padding: 0.75rem;
   border-radius: 0 0 0.3rem 0.3rem;
   font: 12px -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial,
   sans-serif, Apple Color Emoji, Segoe UI Emoji;
 }
 
-.file-meta-light {
+.emgithub-container .file-meta-light {
   color: #586069;
   background-color: #f7f7f7;
 }
 
-.file-meta-dark {
+.emgithub-container .file-meta-dark {
   color: #f7f7f7;
   background-color: #586069;
 }
 
-.file-meta a {
+.emgithub-container .file-meta a {
   font-weight: 600;
   text-decoration: none;
   border: 0;
 }
 
-.file-meta-light a {
+.emgithub-container .file-meta-light a {
   color: #666;
 }
 
-.file-meta-dark a {
+.emgithub-container .file-meta-dark a {
   color: #fff;
 }
 
 /* hide content for small device */
 @media (max-width: 575.98px) {
-  .hide-in-phone {
+  .emgithub-container .hide-in-phone {
     display: none;
   }
 }
+
 .emgithub-container {
   position: relative;
 }
 
-.emgithub-toolbar {
+.emgithub-container .toolbar {
   position: absolute;
-  height: 40px;
-  width: 64px;
   right: 0px;
-  padding: 5px;
+  padding: 0.3rem;
 }
 
-.emgithub-copy-btn {
+.emgithub-container .copy-btn {
   display: none;
   border: 1px solid black;
   border-radius: 3px;
-  padding: 6px;
-  color: #586069;
-  background-color: #f7f7f7;
-  font-weight: bold;
+  padding: 0.4rem;
+  font: bold 1em monospace;
   text-decoration: none;
-  text-align: center;
 }
 
-.emgithub-container:hover .emgithub-copy-btn {
+.emgithub-container .copy-btn-light {
+  color: #586069;
+  background-color: #f7f7f7;
+}
+
+.emgithub-container .copy-btn-dark {
+  color: #f7f7f7;
+  background-color: #586069;
+}
+
+.emgithub-container:hover .copy-btn {
   display: block;
 }
 
-.emgithub-container:hover .emgithub-copy-btn.dark-copy-btn {
+.emgithub-container .copy-btn-light:hover {
   color: #f7f7f7;
   background-color: #586069;
 }
 
-.emgithub-container .emgithub-copy-btn:hover {
-  color: #f7f7f7;
-  background-color: #586069;
-}
-
-.emgithub-container .emgithub-copy-btn.dark-copy-btn:hover {
+.emgithub-container .copy-btn-dark:hover {
   color: #586069;
   background-color: #f7f7f7;
 }
 
-.emgithub-container .emgithub-copy-btn:active {
-  background-color: #39a916;
+.emgithub-container .copy-btn-light:active {
+  /* darken #586069 by 20% https://www.cssfontstack.com/oldsites/hexcolortool/ */
+  background-color: #252d36;
 }
 
+.emgithub-container .copy-btn-dark:active {
+  /* darken #f7f7f7 by 20% */
+  background-color: #c4c4c4;
+}
 </style>
 `);
 
@@ -198,12 +204,14 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
   }
 
   const toolbar = document.createElement('div');
-  toolbar.classList.add('emgithub-toolbar');
+  toolbar.classList.add('toolbar');
   if(showCopy) {
     const copyButton = document.createElement('a');
-    copyButton.classList.add('emgithub-copy-btn');
+    copyButton.classList.add('copy-btn');
     if(isDarkStyle) {
-      copyButton.classList.add('dark-copy-btn');
+      copyButton.classList.add('copy-btn-dark');
+    } else {
+      copyButton.classList.add('copy-btn-light');
     }
     copyButton.href = 'javascript:void(0);'
     copyButton.innerHTML = 'Copy';

--- a/embed.js
+++ b/embed.js
@@ -10,7 +10,6 @@ function embed() {
   const showLineNumbers = params.get("showLineNumbers") === "on";
   const showFileMeta = params.get("showFileMeta") === "on";
   const showCopy = params.get("showCopy") === "on";
-  const showShare = params.get("showShare") === "on";
   const lineSplit = target.hash.split("-");
   const startLine = target.hash !== "" && lineSplit[0].replace("#L", "") || -1;
   const endLine = target.hash !== "" && lineSplit.length > 1 && lineSplit[1].replace("L", "") || startLine;
@@ -97,12 +96,12 @@ function embed() {
 
   Promise.all(showLineNumbers ? [fetchFile, loadHLJS, loadHLJSNum] : [fetchFile, loadHLJS]).then((result) => {
     const targetDiv = document.getElementById(containerId);
-    embedCodeToTarget(targetDiv, result[0], showBorder, showLineNumbers, showFileMeta, showCopy, showShare, isDarkStyle, target.href, rawFileURL, fileExtension, startLine, endLine, tabSize);
+    embedCodeToTarget(targetDiv, result[0], showBorder, showLineNumbers, showFileMeta, showCopy, isDarkStyle, target.href, rawFileURL, fileExtension, startLine, endLine, tabSize);
   }).catch((error) => {
     const errorMsg = `Failed to process ${rawFileURL}
 ${error}`;
     const targetDiv = document.getElementById(containerId);
-    embedCodeToTarget(targetDiv, errorMsg, showBorder, showLineNumbers, showFileMeta, showCopy, showShare, isDarkStyle, target.href, rawFileURL, 'plaintext', -1, -1, tabSize);
+    embedCodeToTarget(targetDiv, errorMsg, showBorder, showLineNumbers, showFileMeta, showCopy, isDarkStyle, target.href, rawFileURL, 'plaintext', -1, -1, tabSize);
   });
 }
 
@@ -116,7 +115,8 @@ function loadScript(src) {
   });
 }
 
-function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, showFileMeta, showCopy, showShare, isDarkStyle, fileURL, rawFileURL, lang, startLine, endLine, tabSize) {
+function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, showFileMeta, showCopy, isDarkStyle, fileURL, rawFileURL, lang, startLine, endLine, tabSize) {
+  const targetDivID = targetDiv.getAttribute('id');
   const fileContainer = document.createElement("div");
   fileContainer.style.margin = "1em 0";
 
@@ -156,22 +156,21 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
   toolbar.classList.add('emgithub-toolbar');
   if(showCopy) {
     const copyButton = document.createElement('button');
+    copyButton.setAttribute('data-clipboard-target', `#${targetDivID} .emgithub-code`)
     copyButton.innerHTML = 'Copy';
     fileContainer.appendChild(copyButton);
-  }
-  if(showShare) {
-    const shareButton = document.createElement('button');
-    shareButton.innerHTML = 'Share';
-    fileContainer.appendChild(shareButton);
-  }
+    let clipboard = new ClipboardJS(copyButton);
+    clipboard.on('success', function(e) {    
+        e.clearSelection();
+    });
 
-  if(showCopy || showShare) {
     fileContainer.appendChild(toolbar);
   }
 
   // Not use a real `pre` to avoid style being overwritten
   // Simulate a real one by using its default style
   const customPre = document.createElement("div");
+  customPre.classList.add('emgithub-code');
   customPre.style.whiteSpace = "pre";
   customPre.style.tabSize = tabSize;
   customPre.appendChild(code);

--- a/embed.js
+++ b/embed.js
@@ -163,7 +163,6 @@ function loadScript(src) {
 }
 
 function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, showFileMeta, showCopy, isDarkStyle, fileURL, rawFileURL, lang, startLine, endLine, tabSize) {
-  const targetDivID = targetDiv.getAttribute('id');
   const fileContainer = document.createElement("div");
   fileContainer.style.margin = "1em 0";
 

--- a/embed.js
+++ b/embed.js
@@ -209,17 +209,10 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
     }
     copyButton.href = 'javascript:void(0);'
     copyButton.innerHTML = 'Copy';
-    copyButton.addEventListener('click', function(event){
-      const copyButton = event.target;
-      let currentParent = copyButton.parentElement;
-      while(!currentParent.classList.contains("emgithub-container")) {
-        currentParent = currentParent.parentElement;
-      }
-      const codeElement = currentParent.querySelector('.emgithub-code');
-      const text = codeElement.innerText;
-
-      // NOTE: text has extra whitespace as DOM elements are stripped. Can we clean that up?
-      copyTextToClipboard(text);
+    copyButton.addEventListener('click', function(e){
+      e.preventDefault();
+      e.cancelBubble = true;
+      copyTextToClipboard(codeText);
     });
     
     toolbar.appendChild(copyButton);

--- a/embed.js
+++ b/embed.js
@@ -202,6 +202,18 @@ function embedCodeToTarget(targetDiv, codeText, showBorder, showLineNumbers, sho
     }
     copyButton.href = 'javascript:void(0);'
     copyButton.innerHTML = 'Copy';
+    copyButton.addEventListener('click', function(event){
+      const copyButton = event.target;
+      let currentParent = copyButton.parentElement;
+      while(!currentParent.classList.contains("emgithub-container")) {
+        currentParent = currentParent.parentElement;
+      }
+      const codeElement = currentParent.querySelector('.emgithub-code');
+      const text = codeElement.innerText;
+
+      // NOTE: text has extra whitespace as DOM elements are stripped. Can we clean that up?
+      copyTextToClipboard(text);
+    });
     
     toolbar.appendChild(copyButton);
     fileContainer.appendChild(toolbar);

--- a/embed.js
+++ b/embed.js
@@ -89,6 +89,9 @@ function embed() {
   padding: 6px;
   color: #586069;
   background-color: #f7f7f7;
+  font-weight: bold;
+  text-decoration: none;
+  text-align: center;
 }
 
 .emgithub-container:hover .emgithub-copy-btn {
@@ -108,6 +111,10 @@ function embed() {
 .emgithub-container .emgithub-copy-btn.dark-copy-btn:hover {
   color: #586069;
   background-color: #f7f7f7;
+}
+
+.emgithub-container .emgithub-copy-btn:active {
+  background-color: #39a916;
 }
 
 </style>


### PR DESCRIPTION
Add a "copy" button that can copy the current code block into the clipboard, per this feature request https://github.com/yusanshi/embed-like-gist/issues/9

- Adds clipboard.js to the 404.html page
  - I'm not opposed to using something like the 404.html page uses versus embedding a new script. 
- Adds "Show Copy Button" checkbox to the main form
- When "show copy button" is on, a "copy" button appears in the embedded code block.
  - Clicking the button copies the contents of the code block to the clipboard (via clipboard.js)

Dark theme:
![image](https://user-images.githubusercontent.com/149965/113512687-c53e5780-9533-11eb-986f-64b9f385b26b.png)

Light them:
![image](https://user-images.githubusercontent.com/149965/113512762-164e4b80-9534-11eb-8749-5b0287167db0.png)



### TODO:
- Style button (or make a link)
- Use a "copy" icon for the button?