### PR TITLE
Strip unnecesarry indentation from code snippets

### DIFF
--- a/embed-v2.js
+++ b/embed-v2.js
@@ -403,6 +403,15 @@
       } else {
         codeText = result[0].reason;
       }
+      
+      // Strip leading whitespace as otherwise we get pointless whitespace/indentation for code snippets from the middle of functions
+      let stripText = "\n"
+      while (codeText[0] === " ")
+      {
+        codeText = codeText.slice(1);
+        stripText += " "
+      }
+      codeText = codeText.replace(new RegExp(stripText, 'g'), "\n");
 
       const codeTag = targetDiv.querySelector("code");
       codeTag.textContent = codeText;

--- a/embed-v2.js
+++ b/embed-v2.js
@@ -394,24 +394,30 @@
           // First remove the ending newline
           codeText = codeText.slice(0, -1);
         }
+
+        let codeTextSplit = codeText.split("\n");
         if (startLine > 0) {
-          codeTextSplit = codeText.split("\n");
-          codeText = codeTextSplit.slice(startLine - 1, endLine).join("\n");
+          codeTextSplit = codeTextSplit.slice(startLine - 1, endLine);
         }
+
+        // Strip leading whitespace as otherwise we get pointless whitespace/indentation
+        // for code snippets from the middle of functions (#22)
+        while (true) {
+          const firstChars = codeTextSplit.filter(s => s.length > 0).map(s => s[0]);
+          if (new Set(firstChars).size == 1 && [' ', '\t'].includes(firstChars[0])) {
+            // If all the lines begin with ' ' or '\t', strip the first char
+            codeTextSplit = codeTextSplit.map(s => s.slice(1));
+          } else {
+            break;
+          }
+        }
+
+        codeText = codeTextSplit.join("\n");
         // Then add the newline back
         codeText = codeText + "\n";
       } else {
         codeText = result[0].reason;
       }
-      
-      // Strip leading whitespace as otherwise we get pointless whitespace/indentation for code snippets from the middle of functions
-      let stripText = "\n"
-      while (codeText[0] === " ")
-      {
-        codeText = codeText.slice(1);
-        stripText += " "
-      }
-      codeText = codeText.replace(new RegExp(stripText, 'g'), "\n");
 
       const codeTag = targetDiv.querySelector("code");
       codeTag.textContent = codeText;


### PR DESCRIPTION
When code snippets are linked that are inside a function (or maybe even a few blocks of logic) we get output like:
`<space><space><space><space>foo =8;`
instead of:
`foo =8;`

Which leads to ugly snippets that show a scrollbar when its not necessary etc. etc.
Instead we should just figure out the indentation level of the code from the first line and then strip that much indentation from any subsequent lines.