### PR TITLE
Add markdown dark mode

### DIFF
--- a/embed-v2.js
+++ b/embed-v2.js
@@ -6,7 +6,7 @@
   const style = params.get("style");
   const styleClassName = `hljs-style-${style.replace(/[^a-zA-Z0-9]/g, '-')}`;
   const lightStyles = ['default', 'a11y-light', 'arduino-light', 'ascetic', 'atom-one-light', 'brown-paper', 'color-brewer', 'docco', 'foundation', 'github', 'googlecode', 'gradient-light', 'grayscale', 'idea', 'intellij-light', 'isbl-editor-light', 'kimbie-light', 'lightfair', 'magula', 'mono-blue', 'nnfx-light', 'panda-syntax-light', 'paraiso-light', 'purebasic', 'qtcreator-light', 'routeros', 'school-book', 'stackoverflow-light', 'tokyo-night-light', 'vs', 'xcode', 'base16/atelier-cave-light', 'base16/atelier-dune-light', 'base16/atelier-estuary-light', 'base16/atelier-forest-light', 'base16/atelier-heath-light', 'base16/atelier-lakeside-light', 'base16/atelier-plateau-light', 'base16/atelier-savanna-light', 'base16/atelier-seaside-light', 'base16/atelier-sulphurpool-light', 'base16/brush-trees', 'base16/classic-light', 'base16/cupcake', 'base16/cupertino', 'base16/default-light', 'base16/dirtysea', 'base16/edge-light', 'base16/equilibrium-gray-light', 'base16/equilibrium-light', 'base16/fruit-soda', 'base16/github', 'base16/google-light', 'base16/grayscale-light', 'base16/gruvbox-light-hard', 'base16/gruvbox-light-medium', 'base16/gruvbox-light-soft', 'base16/harmonic16-light', 'base16/heetch-light', 'base16/horizon-light', 'base16/humanoid-light', 'base16/ia-light', 'base16/material-lighter', 'base16/mexico-light', 'base16/one-light', 'base16/papercolor-light', 'base16/ros-pine-dawn', 'base16/sagelight', 'base16/shapeshifter', 'base16/silk-light', 'base16/solar-flare-light', 'base16/solarized-light', 'base16/summerfruit-light', 'base16/synth-midnight-terminal-light', 'base16/tomorrow', 'base16/unikitty-light', 'base16/windows-10-light', 'base16/windows-95-light', 'base16/windows-high-contrast-light', 'base16/windows-nt-light'];
-  const isDarkStyle = !lightStyles.includes(style) && type === 'code';
+  const isDarkStyle = !lightStyles.includes(style) && (type === 'code' || type === 'markdown');
   const showBorder = params.get("showBorder") === "on";
   const showLineNumbers = params.get("showLineNumbers") === "on";
   const showFileMeta = params.get("showFileMeta") === "on";
@@ -95,6 +95,7 @@
 
   .emgithub-file-dark {
     border: 1px solid #555;
+    background: black;
   }
 
 
@@ -350,7 +351,8 @@
 
   if (type === 'markdown' || type === 'ipynb') {
     const loadMarked = typeof marked != "undefined" ? Promise.resolve() : loadScript('https://cdn.jsdelivr.net/npm/marked@4.0.18/marked.min.js');
-    const loadMarkdownStyle = fetch('https://cdn.jsdelivr.net/gh/sindresorhus/github-markdown-css@5.1.0/github-markdown-light.min.css')
+    const loadMarkdownStyle = (isDarkStyle ? fetch('https://cdn.jsdelivr.net/gh/sindresorhus/github-markdown-css@5.1.0/github-markdown-dark.min.css') :
+    fetch('https://cdn.jsdelivr.net/gh/sindresorhus/github-markdown-css@5.1.0/github-markdown-light.min.css'))
       .then((response) => response.text())
       .then((text) => {
         insertStyle(text);

--- a/embed-v2.js
+++ b/embed-v2.js
@@ -358,6 +358,10 @@
       .then((response) => response.text())
       .then((text) => {
         insertStyle(text);
+        // TODO: `scopeCss` can not handle `github-markdown-css` well.
+        // So currently you should not mix the usage of light and dark styles for markdown or jupyter files
+        // (but use two different light (or dark) styles in a page are OK)
+        // insertStyle(scopeCss(text, '.' + styleClassName));
       });
 
     const loadKatexStyle = fetch('https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css')

--- a/embed-v2.js
+++ b/embed-v2.js
@@ -6,7 +6,7 @@
   const style = params.get("style");
   const styleClassName = `hljs-style-${style.replace(/[^a-zA-Z0-9]/g, '-')}`;
   const lightStyles = ['default', 'a11y-light', 'arduino-light', 'ascetic', 'atom-one-light', 'brown-paper', 'color-brewer', 'docco', 'foundation', 'github', 'googlecode', 'gradient-light', 'grayscale', 'idea', 'intellij-light', 'isbl-editor-light', 'kimbie-light', 'lightfair', 'magula', 'mono-blue', 'nnfx-light', 'panda-syntax-light', 'paraiso-light', 'purebasic', 'qtcreator-light', 'routeros', 'school-book', 'stackoverflow-light', 'tokyo-night-light', 'vs', 'xcode', 'base16/atelier-cave-light', 'base16/atelier-dune-light', 'base16/atelier-estuary-light', 'base16/atelier-forest-light', 'base16/atelier-heath-light', 'base16/atelier-lakeside-light', 'base16/atelier-plateau-light', 'base16/atelier-savanna-light', 'base16/atelier-seaside-light', 'base16/atelier-sulphurpool-light', 'base16/brush-trees', 'base16/classic-light', 'base16/cupcake', 'base16/cupertino', 'base16/default-light', 'base16/dirtysea', 'base16/edge-light', 'base16/equilibrium-gray-light', 'base16/equilibrium-light', 'base16/fruit-soda', 'base16/github', 'base16/google-light', 'base16/grayscale-light', 'base16/gruvbox-light-hard', 'base16/gruvbox-light-medium', 'base16/gruvbox-light-soft', 'base16/harmonic16-light', 'base16/heetch-light', 'base16/horizon-light', 'base16/humanoid-light', 'base16/ia-light', 'base16/material-lighter', 'base16/mexico-light', 'base16/one-light', 'base16/papercolor-light', 'base16/ros-pine-dawn', 'base16/sagelight', 'base16/shapeshifter', 'base16/silk-light', 'base16/solar-flare-light', 'base16/solarized-light', 'base16/summerfruit-light', 'base16/synth-midnight-terminal-light', 'base16/tomorrow', 'base16/unikitty-light', 'base16/windows-10-light', 'base16/windows-95-light', 'base16/windows-high-contrast-light', 'base16/windows-nt-light'];
-  const isDarkStyle = !lightStyles.includes(style) && (type === 'code' || type === 'markdown');
+  const isDarkStyle = !lightStyles.includes(style);
   const showBorder = params.get("showBorder") === "on";
   const showLineNumbers = params.get("showLineNumbers") === "on";
   const showFileMeta = params.get("showFileMeta") === "on";
@@ -95,7 +95,7 @@
 
   .emgithub-file-dark {
     border: 1px solid #555;
-    background: black;
+    background-color: #0d1117;
   }
 
 
@@ -239,7 +239,10 @@
 <style>
   .emgithub-file .html-area pre {
     padding: 0;
-    background-color: #fff;
+  }
+
+  .emgithub-file .html-area .nb-output pre {
+    padding: 16px;
   }
 
   .emgithub-file .html-area .nb-cell {
@@ -351,8 +354,7 @@
 
   if (type === 'markdown' || type === 'ipynb') {
     const loadMarked = typeof marked != "undefined" ? Promise.resolve() : loadScript('https://cdn.jsdelivr.net/npm/marked@4.0.18/marked.min.js');
-    const loadMarkdownStyle = (isDarkStyle ? fetch('https://cdn.jsdelivr.net/gh/sindresorhus/github-markdown-css@5.1.0/github-markdown-dark.min.css') :
-    fetch('https://cdn.jsdelivr.net/gh/sindresorhus/github-markdown-css@5.1.0/github-markdown-light.min.css'))
+    const loadMarkdownStyle = fetch(`https://cdn.jsdelivr.net/gh/sindresorhus/github-markdown-css@5.1.0/github-markdown-${isDarkStyle ? 'dark' : 'light'}.min.css`)
       .then((response) => response.text())
       .then((text) => {
         insertStyle(text);


### PR DESCRIPTION
I took the liberty of taking a crack at it myself because it was only like 3 lines of code. Given that the code styles were already grouped in light and dark themes, I decided to just use that so any dark style will return dark markdown and any light style will return light markdown. It would probably be better to swap out the options in the select depending on the whether raw code, markdown or a notebook is chosen but I feel like it works as is for now. What do you think? Feel free to test it out at you own pace, there's no pressure. 