### PR TITLE
Add option to wrap embedded file with <details> disclosure element

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# emgithub
+# emgithub original info
 
 https://emgithub.com/
 
@@ -7,6 +7,10 @@ Embed a file from GitHub repository just like [GitHub Gist](https://gist.github.
 Demo: <https://yusanshi.com/posts/2019-12-17/emgithub/> (scroll to the bottom of the page).
 
 ![](https://user-images.githubusercontent.com/36265606/185886623-f5f5685d-1e99-43c8-8de2-085dd6954dd7.gif)
+
+## This fork - "collapsible"
+
+This fork allows you to add a parameter "Collapsible" to the script call, that wraps the displayed script output in `<details><summary>...</summary>...</details>` tags. 
 
 ## Get started
 

--- a/embed-v2.js
+++ b/embed-v2.js
@@ -10,6 +10,8 @@
   const showBorder = params.get("showBorder") === "on";
   const showLineNumbers = params.get("showLineNumbers") === "on";
   const showFileMeta = params.get("showFileMeta") === "on";
+  const collapsible = params.get("collapsible") === "open" || params.get("collapsible") === "closed";
+  const collapsibleOpen = params.get("collapsible") === "open";
   const showFullPath = params.get("showFullPath") === "on";
   const showCopy = params.get("showCopy") === "on";
   const fetchFromJsDelivr = params.get("fetchFromJsDelivr") === "on";
@@ -299,6 +301,10 @@
 
   <div class="emgithub-file emgithub-file-${isDarkStyle ? 'dark' : 'light'}"
     style="display:none;${showBorder ? '' : 'border:0'}">
+    ${collapsible ? `<details class="emgithub-details"${collapsibleOpen ? ' open':''}>
+      <summary class="emgithub-summary">
+        <a target="_blank" href="${fileURL}">${decodeURIComponent(showFullPath ? filePath : pathSplit[pathSplit.length - 1])}</a>
+      </summary>`:''}
     <div class="file-data ${styleClassName}">
       ${type === 'code' ? `<div class="code-area">
         ${showCopy ? `<a class="copy-btn copy-btn-${isDarkStyle ? 'dark' : 'light'}" href="javascript:void(0)">Copy</a>`
@@ -318,7 +324,7 @@
       delivered <span class="hide-in-phone">with ❤ </span>by <a target="_blank" href="${serviceProvider}">emgithub</a>
     </div>`: ''
     }
-
+    ${collapsible ? `</details>`:''}
   </div>
 
 </div>


### PR DESCRIPTION
Hello @yusanshi, thanks for this useful script. I've added a feature I needed, so I thought you might want to consider it for inclusion in the main. 

I added an optional "collapsible" attribute. Adding `collapsible=open` or `collapsible=closed` to the parameters you call the script with will wrap the embedded file with `<details class="emgithub-details"><summary class="emgithub-summary">`[file title]`</summary>` above the file's contents, then wrap it up with a `</details>` below, with the default state open or closed, as defined by the chosen value.  