### PR TITLE
Calculate correct iframe height

### DIFF
--- a/404.html
+++ b/404.html
@@ -623,26 +623,15 @@
    function onStyleChange(targetEl, callback) {
      // create a MutationObserver with a callback function
      const observer = new MutationObserver((mutations) => {
-       // loop through the mutations array
-       for (let mutation of mutations) {
-         // check if the mutation type is 'attributes' and the attribute name is 'style'
-         if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
-           // get the target element of the mutation
-           const target = mutation.target;
-           // get the old and new values of the style attribute
-           const oldValue = mutation.oldValue;
-           const newValue = target.getAttribute('style');
-           // compare the old and new values and call callback function
-           callback()
-         }
-       }
+       // call callback once upon any mutation
+       callback()
      });
 
      // specify the options for the observer
      const options = {
        attributes: true, // observe changes in attributes
        attributeFilter: ['style'], // only observe changes in the 'style' attribute
-       attributeOldValue: true, // report the old value of the attribute
+       attributeOldValue: false, // do not report the old value of the attribute
      };
      observer.observe(targetEl, options)
    }

--- a/404.html
+++ b/404.html
@@ -625,6 +625,8 @@
      const observer = new MutationObserver((mutations) => {
        // call callback once upon any mutation
        callback()
+       // disconnect the observer after the callback is done
+       observer.disconnect();
      });
 
      // specify the options for the observer

--- a/404.html
+++ b/404.html
@@ -475,8 +475,12 @@
           previewArea.appendChild(script);
 
           const iframeURL = jsURL.replace('embed-v2.js', 'iframe.html');
-          const iframeTag = `<iframe frameborder="0" style="width:100%; height:500px;" allow="clipboard-write" src=\"${iframeURL}\"><\/iframe>`;
-          document.querySelector("#embededIframeCode").value = iframeTag;
+          const iframeTag = `<iframe frameborder="0" scrolling="no" style="width:100%; height:%HEIGHT%px;" allow="clipboard-write" src=\"${iframeURL}\"><\/iframe>`;
+          script.onload = function () {
+            onStyleChange(previewArea.querySelector(".lds-ring"), function () {
+              document.querySelector("#embededIframeCode").value = iframeTag.replace("%HEIGHT%", previewArea.offsetHeight);
+            })
+          }
         } else {
           targetInput.classList.remove("is-valid");
           targetInput.classList.add("is-invalid");
@@ -615,6 +619,33 @@
       }
       return parts;
     }
+
+   function onStyleChange(targetEl, callback) {
+     // create a MutationObserver with a callback function
+     const observer = new MutationObserver((mutations) => {
+       // loop through the mutations array
+       for (let mutation of mutations) {
+         // check if the mutation type is 'attributes' and the attribute name is 'style'
+         if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+           // get the target element of the mutation
+           const target = mutation.target;
+           // get the old and new values of the style attribute
+           const oldValue = mutation.oldValue;
+           const newValue = target.getAttribute('style');
+           // compare the old and new values and call callback function
+           callback()
+         }
+       }
+     });
+
+     // specify the options for the observer
+     const options = {
+       attributes: true, // observe changes in attributes
+       attributeFilter: ['style'], // only observe changes in the 'style' attribute
+       attributeOldValue: true, // report the old value of the attribute
+     };
+     observer.observe(targetEl, options)
+   }
   </script>
 </body>
 

--- a/iframe.html
+++ b/iframe.html
@@ -10,6 +10,9 @@
     <script>
         const script = document.createElement('script');
         script.src = window.location.href.replace('iframe.html', 'embed-v2.js');
+        script.onload = function () {
+            document.querySelector(".emgithub-file").style.margin = "0";
+        }
         document.querySelector("body").appendChild(script);
     </script>
 </body>


### PR DESCRIPTION
Context: https://github.com/yusanshi/emgithub/pull/35#issuecomment-1871309514
1. Calculate correct iframe height using the preview (*hack*: by detecting when loading screen gets hidden; onload of `<script>` doesn't detect when the contents are ready, but only detect the loading screen)
2. Remove margin to render script's contents without any space; currently the script is adding a margin of 1em at https://github.com/yusanshi/emgithub/blob/aa6f7595f92f38773c5fb181984a1eb7a04e5083/embed-v2.js#L89

This resolves the problem raised in the comment, https://github.com/yusanshi/emgithub/pull/35#issuecomment-1871309514