### PR TITLE
Add "Set max height" option to make it scrollable

### DIFF
--- a/404.html
+++ b/404.html
@@ -338,6 +338,19 @@
           </i>
         </label>
       </div>
+      <div class="row g-0 align-items-center">
+        <div class="form-check form-check-inline col-auto">
+          <input type="checkbox" class="form-check-input" id="setMaxHeight">
+          <label class="form-check-label" for="setMaxHeight">Set max height</label>
+        </div>
+        <div class="col-auto">
+          <div class="input-group input-group-sm">
+            <input type="number" class="form-control" name="maxHeight" id="maxHeight" min="1" value="500"
+              aria-describedby="maxHeightUnit">
+            <span class="input-group-text" id="maxHeightUnit">px</span>
+          </div>
+        </div>
+      </div>
     </form>
 
     <label for="embededScriptCode" class="form-label"><code>&lt;script&gt;</code> to embed</label>
@@ -432,7 +445,7 @@
 
 
       // Load options from localStorage if possible
-      ['showBorder', 'showLineNumbers', 'showFileMeta', 'showFullPath', 'showCopy', 'fetchFromJsDelivr'].forEach(e => {
+      ['showBorder', 'showLineNumbers', 'showFileMeta', 'showFullPath', 'showCopy', 'fetchFromJsDelivr', 'setMaxHeight'].forEach(e => {
         const isShown = localStorage.getItem(e);
         if (isShown !== null) {
           document.getElementById(e).checked = (isShown === 'true');
@@ -442,6 +455,10 @@
       if (style !== null) {
         document.getElementById('style').value = style;
       }
+      const maxHeight = localStorage.getItem('maxHeight');
+      if (maxHeight !== null) {
+        document.getElementById('maxHeight').value = maxHeight;
+      }
 
       const targetInput = document.querySelector("#target");
 
@@ -450,7 +467,7 @@
         e.preventDefault();
 
         // Save current options using localStorage
-        ['showBorder', 'showLineNumbers', 'showFileMeta', 'showFullPath', 'showCopy', 'fetchFromJsDelivr'].forEach(e => {
+        ['showBorder', 'showLineNumbers', 'showFileMeta', 'showFullPath', 'showCopy', 'fetchFromJsDelivr', 'setMaxHeight'].forEach(e => {
           const element = document.getElementById(e);
           if (!element.parentElement.classList.contains('d-none')) {
             // Only save the non-hidden options
@@ -459,6 +476,7 @@
           }
         });
         localStorage.setItem('style', document.getElementById('style').value);
+        localStorage.setItem('maxHeight', document.getElementById('maxHeight').value);
 
         const target = targetInput.value;
         const pattern = /^https:\/\/github\.com\/(?:[A-Za-z0-9_\-\.]+\/){2}blob\/[A-Za-z0-9_\-\.]+\//;
@@ -506,6 +524,9 @@
 
       toggleFullPathCheckDisplay();
       document.querySelector("#showFileMeta").addEventListener('change', toggleFullPathCheckDisplay);
+
+      toggleMaxHeightInputDisable();
+      document.querySelector("#setMaxHeight").addEventListener('change', toggleMaxHeightInputDisable);
 
       document.querySelector("#type").addEventListener('change', toggleCheckStatus);
 
@@ -557,6 +578,15 @@
         showFullPathCheck.classList.remove('d-none');
       } else {
         showFullPathCheck.classList.add('d-none');
+      }
+    }
+
+    function toggleMaxHeightInputDisable() {
+      const maxHeightInput = document.querySelector('#maxHeight');
+      if (document.querySelector('#setMaxHeight').checked) {
+        maxHeightInput.removeAttribute('disabled');
+      } else {
+        maxHeightInput.setAttribute('disabled', 'disabled');
       }
     }
 

--- a/embed-v2.js
+++ b/embed-v2.js
@@ -13,6 +13,10 @@
   const showFullPath = params.get("showFullPath") === "on";
   const showCopy = params.get("showCopy") === "on";
   const fetchFromJsDelivr = params.get("fetchFromJsDelivr") === "on";
+  const maxHeight = (() => {
+    const parsedValue = Number.parseInt(params.get('maxHeight'), 10);
+    return Number.isNaN(parsedValue) ? undefined : parsedValue;
+  })();
   const lineSplit = target.hash.split("-");
   const startLine = target.hash !== "" && lineSplit[0].replace("#L", "") || -1;
   const endLine = target.hash !== "" && lineSplit.length > 1 && lineSplit[1].replace("L", "") || startLine;
@@ -231,6 +235,13 @@
     padding: 0.8em;
   }
 
+  /* use where() for backward compatibility */
+  :where(.emgithub-file .code-area pre code.hljs) {
+    box-sizing: border-box;
+    max-height: ${maxHeight ? maxHeight + 'px' : 'none'};
+    overflow-y: ${maxHeight ? 'auto' : 'visible'};
+  }
+
   .emgithub-file .code-area .hide-line-numbers .hljs-ln-numbers {
     display: none;
   }
@@ -274,6 +285,12 @@
     max-width: 980px;
     margin: 0 auto;
     padding: 45px;
+  }
+
+  /* use where() for backward compatibility */
+  :where(.emgithub-file .html-area.markdown-body) {
+    max-height: ${maxHeight ? maxHeight + 'px' : 'none'};
+    overflow-y: ${maxHeight ? 'auto' : 'visible'};
   }
 
   /* Reserve space for "In [1]", "Out [1]" */


### PR DESCRIPTION
Thank you for providing such a convenient and powerful application!

Sometimes, I want to limit the height of embedded content and enable scrolling, especially for longer code files or markdown content. I implemented a "Set Max Height" option to address this need.

## Preview

- raw code ![image](https://github.com/user-attachments/assets/f728b434-5fba-4bcf-b7c8-6a66dcd9a873)
- Markdown/Jupyter Notebook ![image](https://github.com/user-attachments/assets/9f04b357-447c-4263-9639-7287db8b3255)

## Changes

1. Updated `embed-v2.js` to support a new `maxHeight` parameter, which dynamically applies `max-height` and `overflow-y` styles to embedded content.
2. The frontend now has a corresponding "Set max height" input field, allowing users to specify the maximum height in pixels.

## About Breaking Changes

To ensure backward compatibility for users who have already written custom styles like the following:

```css
.emgithub-file .code-area pre code.hljs {
    max-height: 200px;
    overflow-y: auto;
}
```

I used the `:where()` selector to apply the maxHeight setting. This ensures it does not override user-defined styles unless explicitly set.

If the use of `:where()` is not acceptable, I can create a new `embed-v3.js` implementation to avoid affecting existing users. Please let me know your preference!
